### PR TITLE
fix README documentation on symlink hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Given any digest algorithm `H` (a Hash function algorithm),
 a `RecursiveDigest(H, path)` is:
 
 * for a file: `H("F" || file_content)`
-* for a symlink: `H("S" || symlink_content)`
+* for a symlink: `H("L" || symlink_content)`
 * for a directory: `H("D" || directory_content)`
 
 As you can see a one-letter ASCII prefix is used to make it impossible


### PR DESCRIPTION
README states that symlink contents are prefixed with "S", whereas it's actually "L": https://github.com/crev-dev/recursive-digest/blob/master/src/lib.rs#L307

 Threw me off for a bit when implementing this in Node.js!