### PR TITLE
fix: hash non-UTF-8 filenames losslessly on unix and Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,27 @@ If optional additional data extensions is used, the `H(entry_name)` above become
 data is unspecified, but was intendet for fielsystem metadata like file system
 permissions and ownership.
 
+## Portability of non-UTF-8 paths
+
+Filenames and symlink targets that are valid UTF-8 are hashed as their
+UTF-8 bytes on every platform, so the resulting digest is bit-identical
+across operating systems. This is the portable case and covers the
+overwhelming majority of real-world trees.
+
+Filenames and symlink targets that are **not** valid UTF-8 cannot be
+hashed portably, because unix and Windows store them in fundamentally
+different byte representations. In that case the library falls back to
+the platform's native encoding:
+
+* on unix, the raw bytes of the `OsStr` (`OsStrExt::as_bytes`);
+* on Windows, the UTF-16 code units from `OsStrExt::encode_wide`
+  encoded as little-endian bytes (this captures unpaired surrogates);
+* on any other platform, the digest computation fails with
+  `DigestError::OsStrConversionError`, because there is no defined
+  byte representation to fall back to.
+
+If you rely on cross-platform reproducibility of digests, treat any
+tree containing non-UTF-8 path components as not portably
+content-addressable.
+
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,15 +162,46 @@ where
     }
 }
 
-#[cfg(unix)]
-fn hash_osstr<D: digest::Digest>(digest: &mut D, s: &OsStr) {
-    use std::os::unix::ffi::OsStrExt;
-    digest.update(s.as_bytes());
-}
+/// Feed the bytes of an [`OsStr`] into `digest`.
+///
+/// When `s` is valid UTF-8 we hash its UTF-8 bytes — this is the only
+/// path that produces a portable digest across platforms, and it is the
+/// overwhelmingly common case (all-ASCII / all-Unicode filenames).
+///
+/// When `s` is *not* valid UTF-8 we fall back to the platform's native
+/// byte representation, at the cost of cross-platform reproducibility
+/// (see the "Portability of non-UTF-8 paths" section of the README):
+///
+/// * on unix, the raw bytes from `OsStrExt::as_bytes()`;
+/// * on windows, the UTF-16 code units from `OsStrExt::encode_wide()`
+///   encoded as little-endian bytes (captures unpaired surrogates);
+/// * on other platforms we have no byte representation to fall back to
+///   and return [`DigestError::OsStrConversionError`].
+fn hash_osstr<D: digest::Digest>(digest: &mut D, s: &OsStr) -> Result<(), DigestError> {
+    if let Some(utf8) = s.to_str() {
+        digest.update(utf8.as_bytes());
+        return Ok(());
+    }
 
-#[cfg(not(unix))]
-fn hash_osstr<D: digest::Digest>(digest: &mut D, s: &OsStr) {
-    digest.update(s.to_string_lossy().as_bytes());
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        digest.update(s.as_bytes());
+        Ok(())
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        for unit in s.encode_wide() {
+            digest.update(unit.to_le_bytes());
+        }
+        Ok(())
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = digest;
+        Err(DigestError::OsStrConversionError)
+    }
 }
 
 impl<D, FFilter, FAData> RecursiveDigest<D, FFilter, FAData>
@@ -238,7 +269,7 @@ where
                 hash_osstr(
                     &mut name_hasher,
                     entry.path().file_name().expect("must have a file_name"),
-                );
+                )?;
                 // additional data (optional)
                 (self.additional_data)(
                     &entry,


### PR DESCRIPTION
Previously the non-unix branch of hash_osstr silently lossy-decoded filenames via OsStr::to_string_lossy, which produces a different digest from the unix (raw-bytes) path for filenames containing non-UTF-8 bytes. The recursive digest was meant to be a content-addressed identifier but was silently platform-dependent in edge cases.

Reshape hash_osstr to:

* hash the UTF-8 bytes when the OsStr is valid UTF-8 — this is the only path that produces a portable digest, and it covers the overwhelmingly common case;
* otherwise, fall back to the platform's native byte representation (raw bytes on unix, UTF-16 LE of encode_wide() on windows) so that non-UTF-8 filenames can still be digested losslessly;
* on platforms that are neither unix nor windows, return OsStrConversionError since we have no defined byte representation.

Document the tradeoff (portable UTF-8 path vs platform-specific fallback) in the README.